### PR TITLE
Check for lowercase utf8 locale specifier

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -37,7 +37,7 @@ install=ros2-galactic.install
 prepare() {
     # Check locale according to
     # https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html#set-locale
-    if ! locale | grep LANG | grep UTF-8 > /dev/null; then
+    if ! locale | grep LANG | grep 'UTF-8\|utf8' > /dev/null; then
         echo 'Your locale must support UTF-8. See ' \
              'https://wiki.archlinux.org/index.php/locale and ' \
              'https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html#set-locale'


### PR DESCRIPTION
Fixes #28 by extending the grep command to check for both the uppercase `UTF-8` specifier and the lowercase `utf8` specifier.