### PR TITLE
Fix `free` translation error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -85,7 +85,8 @@ prepare() {
 
 build() {
     # Disable parallel build if RAM is low
-    if [[ $(free | grep -Po "Mem:\s+\K\d+") -lt 16000000 ]]; then
+    MIN_PARALLEL_BUILD_RAM_KB=16000000
+    if [[ $(free | grep -Po "Mem:\s+\K\d+") -lt $MIN_PARALLEL_BUILD_RAM_KB && $(grep MemTotal /proc/meminfo | grep -Po "MemTotal:\s+\K\d+") -lt $MIN_PARALLEL_BUILD_RAM_KB ]]; then
         printf "\nRAM is smaller than 16 GB. Parallel build will be disabled for stability.\n\n"
         export COLCON_EXTRA_ARGS="${COLCON_EXTRA_ARGS} --executor sequential"
     fi


### PR DESCRIPTION
If your system language is other than English, output from 'free' command is translated.
Add double-check ram, which uses different commands to be sure about available ram.