### PR TITLE
Fix pyqt/sip4 compatibility issue

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,10 +17,9 @@ arch=('any')
 license=('Apache')
 depends=(
     'ros2-arch-deps'
-    'ros2-pyqt5-sip-compat'
+    'python-pyqt5-sip4'
     'assimp'
     'gmock'
-    'sip4'
 )
 source=(
     "ros2::git+https://github.com/ros2/ros2#tag=release-galactic-20210716"


### PR DESCRIPTION
Fix for #9 by replacing `sip4` and `ros2-pyqt5-sip-compat` deps with `python-pyqt5-sip4` as suggested in the linked issue.
Confirmed working on my machine when installing ros2-galactic (with paru).